### PR TITLE
feat: Add trained quality model and expand project scope

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.pth filter=lfs diff=lfs merge=lfs -text
+*.pt filter=lfs diff=lfs merge=lfs -text
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.safetensors filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text
+*.pkl filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
-# Z-Image Data Pipeline
+# Multimodal Data Pipeline
 
-A high-performance, distributed image data processing pipeline built with Ray, featuring Rust-accelerated operators and GPU-optimized CLIP embedding extraction.
+A high-performance, distributed opensource web-scale (hundrends of billions) multimodal data processing pipelines built with Ray, featuring Rust-accelerated and GPU-optimized operators.
+
+This repository aims to replicate SOTA multimodal datapipelines, like
+
+- [Z-Image: An Efficient Image Generation Foundation Model](https://arxiv.org/pdf/2511.22699)
+- [Qwen3-VL](https://arxiv.org/pdf/2511.21631)
+- [Qwen-Image](https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-Image/Qwen_Image.pdf)
+- [HunyuanImage 3.0](https://arxiv.org/pdf/2509.23951)
+- [HunyuanORC](https://github.com/Tencent-Hunyuan/HunyuanOCR)
+- [PaddleOCR 3.0](https://arxiv.org/pdf/2507.05595)
+- [PaddleOCR-VL](https://arxiv.org/pdf/2510.14528)
+- [Seed1.5-VL](https://arxiv.org/pdf/2505.07062)
+- [SeedEdit 3.0](https://arxiv.org/pdf/2506.05083)
+- [BAGEL: The Open-Source Unified Multimodal Model](https://arxiv.org/pdf/2505.14683)
+- [HoneyBee: Data Recipes for Vision-Language Reasoners](https://arxiv.org/pdf/2510.12225)
+- [MiMo-VL](https://arxiv.org/pdf/2506.03569)
+- [Cosmos World Foundation Model Platform for Physical AI](https://arxiv.org/pdf/2501.03575)
 
 ## Architecture
 

--- a/models/quality_assessment/multihead_quality_model.pth
+++ b/models/quality_assessment/multihead_quality_model.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6791d0719d51b6476bfae309ad1b2448c4b2469b689ffbe5dbb7079f5f3e9f3
+size 9600205


### PR DESCRIPTION
## Summary

- Add pre-trained multi-head quality assessment model
- Configure Git LFS for large model files
- Expand project scope to cover multiple SOTA multimodal pipelines

## Changes

### Git LFS Configuration
Track large model files with Git LFS:
- `.pth`, `.pt` - PyTorch models
- `.bin`, `.safetensors` - Transformers models
- `.onnx` - ONNX models
- `.pkl` - Pickle files

### Pre-trained Model
- `models/quality_assessment/multihead_quality_model.pth` (9.6 MB)
- Trained on synthetic data from Tiny-ImageNet

### README Update
Expanded project scope to replicate SOTA multimodal data pipelines:
- Z-Image, Qwen3-VL, Qwen-Image
- HunyuanImage 3.0, HunyuanOCR
- PaddleOCR 3.0, PaddleOCR-VL
- Seed1.5-VL, SeedEdit 3.0
- BAGEL, HoneyBee, MiMo-VL, Cosmos

## Test Plan

- [x] Git LFS correctly tracks model file
- [x] Model file uploads successfully