### PR TITLE
feat: Add ImageAestheticQualityRefiner using CLIP+MLP aesthetic predictor

### DIFF
--- a/operators/refiners/__init__.py
+++ b/operators/refiners/__init__.py
@@ -8,6 +8,7 @@ Refiners are automatically registered when this package is imported.
 
 from framework import OperatorRegistry
 
+from .image_aesthetic_quality import ImageAestheticQualityRefiner
 from .image_clip_embedding import ImageClipEmbeddingRefiner
 from .image_metadata import ImageMetadataRefiner
 from .image_technical_quality import ImageTechnicalQualityRefiner
@@ -18,10 +19,12 @@ OperatorRegistry.register("ImageMetadataRefiner", ImageMetadataRefiner)
 OperatorRegistry.register("ImageTechnicalQualityRefiner", ImageTechnicalQualityRefiner)  # Auto-uses Rust if available
 OperatorRegistry.register("ImageVisualDegradationsRefiner", ImageVisualDegradationsRefiner)
 OperatorRegistry.register("ImageClipEmbeddingRefiner", ImageClipEmbeddingRefiner)
+OperatorRegistry.register("ImageAestheticQualityRefiner", ImageAestheticQualityRefiner)
 
 __all__ = [
     "ImageMetadataRefiner",
     "ImageTechnicalQualityRefiner",
     "ImageVisualDegradationsRefiner",
     "ImageClipEmbeddingRefiner",
+    "ImageAestheticQualityRefiner",
 ]

--- a/operators/refiners/image_aesthetic_quality.py
+++ b/operators/refiners/image_aesthetic_quality.py
@@ -1,0 +1,344 @@
+"""
+Image Aesthetic Quality Refiner
+
+Predicts aesthetic quality scores using CLIP+MLP model from:
+- https://github.com/christophschuhmann/improved-aesthetic-predictor
+- https://huggingface.co/ttj/sac-logos-ava1-l14-linearMSE
+
+The model outputs a score (typically 1-10) predicting how visually appealing
+an image is, based on training from professional annotators (AVA dataset + LAION logos).
+
+This is a Refiner that enriches records with aesthetic quality scores.
+
+Usage:
+1. Reuse existing CLIP embedding (recommended - avoids redundant computation):
+   - First run ImageClipEmbeddingRefiner with ViT-L-14 model
+   - Then run this refiner with embedding_field pointing to that field
+
+2. Compute embedding internally (standalone mode):
+   - Set embedding_field=None, this refiner will load CLIP and compute embeddings
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+from PIL import Image
+
+from framework import Refiner
+
+# Try to import torch and related dependencies
+try:
+    import torch
+    import torch.nn as nn
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+# Try to import huggingface_hub for model downloading
+try:
+    from huggingface_hub import hf_hub_download
+
+    HF_HUB_AVAILABLE = True
+except ImportError:
+    HF_HUB_AVAILABLE = False
+
+# Field name constant
+FIELD_AESTHETIC_SCORE = "image_aesthetic_score"
+
+# Required embedding dimension for the aesthetic predictor (ViT-L/14)
+REQUIRED_EMBEDDING_DIM = 768
+
+
+class AestheticMLP(nn.Module):
+    """MLP model for aesthetic score prediction.
+
+    Architecture from: https://github.com/christophschuhmann/improved-aesthetic-predictor
+    Input: CLIP ViT-L/14 embeddings (768 dimensions)
+    Output: Aesthetic score (typically 1-10)
+    """
+
+    def __init__(self, input_size: int = 768):
+        super().__init__()
+        self.input_size = input_size
+        self.layers = nn.Sequential(
+            nn.Linear(self.input_size, 1024),
+            nn.Dropout(0.2),
+            nn.Linear(1024, 128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 64),
+            nn.Dropout(0.1),
+            nn.Linear(64, 16),
+            nn.Linear(16, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class ImageAestheticQualityRefiner(Refiner):
+    """Refiner for predicting aesthetic quality scores using CLIP+MLP.
+
+    Uses the improved-aesthetic-predictor model trained on AVA dataset + LAION logos.
+    The model predicts how visually appealing an image is on a scale of ~1-10.
+
+    Two modes of operation:
+    1. Reuse existing embedding (recommended): Set `embedding_field` to the field name
+       containing pre-computed CLIP ViT-L-14 embeddings (768-dim).
+    2. Compute embedding internally: Set `embedding_field=None` to load CLIP and compute.
+
+    Output fields:
+    - image_aesthetic_score: Aesthetic quality score (higher = more visually appealing)
+    """
+
+    def __init__(
+        self,
+        embedding_field: str | None = None,
+        model_repo: str = "ttj/sac-logos-ava1-l14-linearMSE",
+        model_filename: str = "model.safetensors",
+        clip_model_name: str = "ViT-L-14",
+        clip_pretrained: str = "openai",
+        device: str = "auto",
+        inference_batch_size: int = 32,
+        use_fp16: bool = True,
+        preprocess_workers: int = 4,
+    ):
+        """Initialize aesthetic quality refiner.
+
+        Args:
+            embedding_field: Field name containing pre-computed CLIP embeddings (768-dim).
+                             If None, will load CLIP model and compute embeddings internally.
+                             Example: "image_clip_emb_vit_l_14" from ImageClipEmbeddingRefiner.
+            model_repo: Hugging Face model repository for the aesthetic predictor MLP
+            model_filename: Filename of the model weights in the repo
+            clip_model_name: OpenCLIP model name (only used if embedding_field is None)
+                             Must be ViT-L-14 for this predictor (768-dim output).
+            clip_pretrained: Pretrained weights identifier (only used if embedding_field is None)
+            device: Device to run model on ("cpu", "cuda", "mps", or "auto")
+            inference_batch_size: Batch size for inference (default: 32)
+            use_fp16: Use FP16 half precision for faster inference (default: True)
+            preprocess_workers: Number of threads for parallel image preprocessing
+                                (only used if embedding_field is None)
+        """
+        super().__init__()
+
+        if not TORCH_AVAILABLE:
+            raise ImportError("torch is required. Install: pip install torch")
+
+        if not HF_HUB_AVAILABLE:
+            raise ImportError("huggingface_hub is required. Install: pip install huggingface_hub")
+
+        self.embedding_field = embedding_field
+        self.inference_batch_size = inference_batch_size
+        self.preprocess_workers = preprocess_workers
+
+        # Handle device selection
+        if device == "auto":
+            if torch.backends.mps.is_available():
+                device = "mps"
+                print("Auto-detected MPS (Mac GPU)")
+            elif torch.cuda.is_available():
+                device = "cuda"
+                print("Auto-detected CUDA")
+            else:
+                device = "cpu"
+                print("Using CPU")
+
+        if device == "mps" and not torch.backends.mps.is_available():
+            device = "cpu"
+        elif device == "cuda" and not torch.cuda.is_available():
+            device = "cpu"
+
+        self.device = torch.device(device)
+
+        # FP16 support (not for MPS which has limited fp16 support)
+        self.use_fp16 = use_fp16 and device == "cuda"
+        self.dtype = torch.float16 if self.use_fp16 else torch.float32
+
+        # Only load CLIP model if we need to compute embeddings ourselves
+        self.clip_model = None
+        self.preprocess = None
+        self._executor = None
+
+        if embedding_field is None:
+            # Standalone mode: load CLIP model
+            try:
+                import open_clip
+
+                self._open_clip = open_clip
+            except ImportError as err:
+                raise ImportError("open-clip-torch is required. Install: pip install open-clip-torch") from err
+
+            print(f"Loading OpenCLIP model: {clip_model_name}/{clip_pretrained} on {device}...")
+            self.clip_model, _, self.preprocess = self._open_clip.create_model_and_transforms(
+                clip_model_name, pretrained=clip_pretrained, device=self.device
+            )
+            self.clip_model.eval()
+
+            # Convert CLIP to FP16 if enabled
+            if self.use_fp16:
+                self.clip_model = self.clip_model.half()
+                print("CLIP using FP16 half precision")
+        else:
+            print(f"Using pre-computed embeddings from field: '{embedding_field}'")
+            print(f"Note: Embeddings must be {REQUIRED_EMBEDDING_DIM}-dim (CLIP ViT-L/14)")
+
+        # Load aesthetic predictor MLP from Hugging Face
+        print(f"Loading aesthetic predictor MLP from: {model_repo}...")
+        self._load_aesthetic_mlp(model_repo, model_filename)
+
+        print(f"Aesthetic Quality Refiner initialized. Output field: {FIELD_AESTHETIC_SCORE}")
+
+    def _load_aesthetic_mlp(self, model_repo: str, model_filename: str) -> None:
+        """Load the aesthetic predictor MLP from Hugging Face."""
+        # Download model from Hugging Face
+        model_path = hf_hub_download(repo_id=model_repo, filename=model_filename)
+
+        # Initialize MLP with CLIP ViT-L/14 embedding size (768)
+        self.aesthetic_mlp = AestheticMLP(input_size=REQUIRED_EMBEDDING_DIM)
+
+        # Load weights - handle both safetensors and pth formats
+        if model_filename.endswith(".safetensors"):
+            try:
+                from safetensors.torch import load_file
+
+                state_dict = load_file(model_path)
+            except ImportError as err:
+                raise ImportError(
+                    "safetensors is required for .safetensors files. Install: pip install safetensors"
+                ) from err
+        else:
+            state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
+
+        self.aesthetic_mlp.load_state_dict(state_dict)
+        self.aesthetic_mlp.to(self.device)
+        self.aesthetic_mlp.eval()
+
+        # Convert MLP to FP16 if enabled (but predictions will be cast to float32)
+        if self.use_fp16:
+            self.aesthetic_mlp = self.aesthetic_mlp.half()
+            print("Aesthetic MLP using FP16 half precision")
+
+        print("Aesthetic predictor MLP loaded successfully")
+
+    def _preprocess_image(self, record: dict[str, Any]) -> torch.Tensor | None:
+        """Preprocess a single image (for parallel execution)."""
+        img_obj = record.get("image", {})
+        if isinstance(img_obj, dict) and "bytes" in img_obj:
+            try:
+                img = Image.open(BytesIO(img_obj["bytes"]))
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                return self.preprocess(img)
+            except Exception:
+                pass
+        return None
+
+    def _get_embeddings_from_field(self, records: list[dict[str, Any]]) -> tuple[torch.Tensor, list[int]]:
+        """Extract embeddings from the specified field in records.
+
+        Returns:
+            Tuple of (embeddings tensor, valid_indices list)
+        """
+        embeddings = []
+        valid_indices = []
+
+        for i, record in enumerate(records):
+            emb = record.get(self.embedding_field)
+            if emb is not None:
+                emb_array = np.array(emb, dtype=np.float32)
+                if len(emb_array) == REQUIRED_EMBEDDING_DIM:
+                    embeddings.append(emb_array)
+                    valid_indices.append(i)
+                else:
+                    print(
+                        f"Warning: Embedding dim mismatch at index {i}: "
+                        f"got {len(emb_array)}, expected {REQUIRED_EMBEDDING_DIM}"
+                    )
+
+        if not embeddings:
+            return torch.tensor([]), []
+
+        # Stack and convert to tensor
+        embeddings_tensor = torch.from_numpy(np.stack(embeddings)).to(self.device, dtype=self.dtype)
+        return embeddings_tensor, valid_indices
+
+    def _compute_embeddings_from_images(self, records: list[dict[str, Any]]) -> tuple[torch.Tensor, list[int]]:
+        """Compute CLIP embeddings from images.
+
+        Returns:
+            Tuple of (embeddings tensor, valid_indices list)
+        """
+        # Lazy init thread pool (can't pickle for Ray serialization)
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=self.preprocess_workers)
+
+        # Parallel preprocess using thread pool
+        results = list(self._executor.map(self._preprocess_image, records))
+
+        # Collect valid tensors and indices
+        tensors = []
+        valid_indices = []
+        for i, tensor in enumerate(results):
+            if tensor is not None:
+                tensors.append(tensor)
+                valid_indices.append(i)
+
+        if not tensors:
+            return torch.tensor([]), []
+
+        # Batch inference for CLIP embeddings
+        batch_tensor = torch.stack(tensors).to(self.device, dtype=self.dtype)
+
+        with torch.inference_mode():
+            image_features = self.clip_model.encode_image(batch_tensor)
+            # Normalize embeddings (L2 normalization)
+            image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+
+        return image_features, valid_indices
+
+    def refine_batch(self, records: list[dict[str, Any]]) -> None:
+        """Predict aesthetic scores for a batch of images inplace (GPU batch inference)."""
+        if not records:
+            return
+
+        # Initialize all records with default score (0.0)
+        for record in records:
+            record[FIELD_AESTHETIC_SCORE] = 0.0
+
+        # Process in mini-batches for efficient GPU usage
+        for batch_start in range(0, len(records), self.inference_batch_size):
+            batch_end = min(batch_start + self.inference_batch_size, len(records))
+            batch_records = records[batch_start:batch_end]
+
+            try:
+                # Get embeddings - either from field or compute from images
+                if self.embedding_field is not None:
+                    embeddings, valid_indices = self._get_embeddings_from_field(batch_records)
+                else:
+                    embeddings, valid_indices = self._compute_embeddings_from_images(batch_records)
+
+                if len(valid_indices) == 0:
+                    continue
+
+                # Predict aesthetic scores
+                with torch.inference_mode():
+                    # Cast to the MLP's dtype (may be fp16 or fp32)
+                    scores = self.aesthetic_mlp(embeddings.to(self.aesthetic_mlp.layers[0].weight.dtype))
+                    # Convert to float32 for output
+                    scores = scores.float().cpu().numpy().flatten()
+
+                for j, idx in enumerate(valid_indices):
+                    batch_records[idx][FIELD_AESTHETIC_SCORE] = float(scores[j])
+
+            except Exception as e:
+                print(f"Warning: Batch inference failed: {e}")
+
+    def get_output_schema(self) -> dict[str, pa.DataType]:
+        """Return output schema for new fields added by this refiner."""
+        return {
+            FIELD_AESTHETIC_SCORE: pa.float32(),
+        }

--- a/pipeline_config.yaml
+++ b/pipeline_config.yaml
@@ -36,34 +36,84 @@ stages:
   #       cpu: 1 # Number of CPUs per worker instance
   #       gpu: 0 # Number of GPUs per worker instance
 
-  - name: embedding_stage
+  # - name: embedding_stage
+  #   operators:
+  #     - name: image_clip_embedding_refiner
+  #       params:
+  #         model_name: "ViT-B-32" # 512-dim embedding
+  #         pretrained: "openai"
+  #         device: "auto"
+  #         normalize: true
+  #         inference_batch_size: 128
+  #         use_fp16: true
+  #         preprocess_workers: 4
+  #       enabled: true
+  #   worker:
+  #     num_replicas: 1 # Single worker for GPU stage (avoid GPU contention)
+  #     resources:
+  #       cpu: 1 # More CPUs for preprocessing threads
+  #       gpu: 0 # Set to 1 if using CUDA GPU
+
+  - name: visual_degradation_scoring_stage
     operators:
-      - name: image_clip_embedding_refiner
+      - name: image_visual_degradations_refiner
         params:
-          model_name: "ViT-B-32" # 512-dim embedding
-          pretrained: "openai"
-          device: "auto"
-          normalize: true
-          inference_batch_size: 128
-          use_fp16: true
-          preprocess_workers: 4
-        enabled: true
+          model_path: models/image_quality_assessment/multihead_quality_model.pth
     worker:
       num_replicas: 1 # Single worker for GPU stage (avoid GPU contention)
       resources:
         cpu: 1 # More CPUs for preprocessing threads
         gpu: 0 # Set to 1 if using CUDA GPU
 
-  - name: visual_degradation_scoring_stage
+  # Aesthetic Quality Scoring Stage (CLIP+MLP aesthetic predictor)
+  # Uses the improved-aesthetic-predictor model from:
+  # https://github.com/christophschuhmann/improved-aesthetic-predictor
+  # Output: image_aesthetic_score (typically 1-10, higher = more visually appealing)
+  #
+  # RECOMMENDED: Use embedding_field to reuse CLIP embeddings from a previous stage.
+  # This avoids redundant CLIP computation. Requires ViT-L-14 embeddings (768-dim).
+  #
+  # Example with pre-computed embeddings (recommended):
+  - name: clip_embedding_stage
     operators:
-      - name: image_visual_degradations_refiner
+      - name: image_clip_embedding_refiner
         params:
-          model_path: models/quality_assessment/multihead_quality_model.pth
+          model_name: "ViT-L-14" # Must be ViT-L-14 for aesthetic predictor
+          pretrained: "openai"
+          inference_batch_size: 32
     worker:
-      num_replicas: 1 # Single worker for GPU stage (avoid GPU contention)
+      num_replicas: 1
       resources:
-        cpu: 1 # More CPUs for preprocessing threads
-        gpu: 0 # Set to 1 if using CUDA GPU
+        cpu: 1
+        gpu: 0
+
+  - name: aesthetic_quality_stage
+    operators:
+      - name: image_aesthetic_quality_refiner
+        params:
+          embedding_field: "image_clip_emb_vit_l_14" # Reuse embeddings from previous stage
+          inference_batch_size: 32
+    worker:
+      num_replicas: 1
+      resources:
+        cpu: 1
+  #
+  # Example standalone (computes CLIP internally, slower):
+  # - name: aesthetic_quality_stage
+  #   operators:
+  #     - name: image_aesthetic_quality_refiner
+  #       params:
+  #         embedding_field: null       # Compute embeddings internally
+  #         clip_model_name: "ViT-L-14"
+  #         clip_pretrained: "openai"
+  #         device: "auto"
+  #         inference_batch_size: 32
+  #         use_fp16: true
+  #   worker:
+  #     num_replicas: 1
+  #     resources:
+  #       cpu: 1
+  #       gpu: 0
 
 data_writer:
   type: ParquetDataWriter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "scikit-learn>=1.3.0",
     "joblib>=1.3.0",
     "open-clip-torch>=3.2.0",
+    "huggingface-hub>=0.20.0",
+    "safetensors>=0.4.0",
 ]
 
 [project.optional-dependencies]
@@ -48,8 +50,8 @@ select = [
     "DTZ", # flake8-datetimez
 ]
 ignore = [
-    "E501",  # line too long (handled by formatter)
-    "B008",  # do not perform function calls in argument defaults
+    "E501", # line too long (handled by formatter)
+    "B008", # do not perform function calls in argument defaults
 ]
 
 [tool.ruff.lint.isort]

--- a/test_image_aesthetic_quality.py
+++ b/test_image_aesthetic_quality.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Test script for ImageAestheticQualityRefiner.
+
+Tests the CLIP+MLP aesthetic score prediction using the model from:
+https://huggingface.co/ttj/sac-logos-ava1-l14-linearMSE
+
+Tests both modes:
+1. Reuse pre-computed embeddings (recommended)
+2. Compute embeddings internally (standalone)
+"""
+
+import io
+import time
+
+from PIL import Image
+
+from operators.refiners.image_aesthetic_quality import ImageAestheticQualityRefiner
+from operators.refiners.image_clip_embedding import ImageClipEmbeddingRefiner
+
+
+def create_test_image(
+    width: int = 512,
+    height: int = 512,
+    color: tuple[int, int, int] = (100, 150, 200),
+    pattern: str = "solid",
+) -> bytes:
+    """Create a test image and return as bytes."""
+    img = Image.new("RGB", (width, height), color)
+
+    if pattern == "gradient":
+        # Create a gradient pattern
+        pixels = img.load()
+        for y in range(height):
+            for x in range(width):
+                r = int(255 * x / width)
+                g = int(255 * y / height)
+                b = int(255 * (x + y) / (width + height))
+                pixels[x, y] = (r, g, b)
+    elif pattern == "noise":
+        # Create a noisy pattern
+        import numpy as np
+
+        noise = np.random.randint(0, 256, (height, width, 3), dtype=np.uint8)
+        img = Image.fromarray(noise)
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="JPEG", quality=90)
+    return buffer.getvalue()
+
+
+def test_with_precomputed_embeddings():
+    """Test mode 1: Reuse pre-computed CLIP embeddings (recommended)."""
+    print("=" * 70)
+    print("Mode 1: Reuse Pre-computed CLIP Embeddings (Recommended)")
+    print("=" * 70)
+
+    # Step 1: Compute CLIP embeddings with ImageClipEmbeddingRefiner
+    print("\n[1] Computing CLIP embeddings with ImageClipEmbeddingRefiner...")
+    print("    (Using ViT-L-14 to match aesthetic predictor requirements)")
+    start = time.time()
+    clip_refiner = ImageClipEmbeddingRefiner(
+        model_name="ViT-L-14",
+        pretrained="openai",
+        normalize=True,
+        inference_batch_size=8,
+        use_fp16=False,
+    )
+    print(f"    CLIP model loaded in {time.time() - start:.2f}s")
+
+    # Create test records
+    test_cases = [
+        ("Solid blue", create_test_image(512, 512, (50, 100, 200), "solid")),
+        ("Gradient", create_test_image(512, 512, (0, 0, 0), "gradient")),
+        ("Random noise", create_test_image(512, 512, (0, 0, 0), "noise")),
+    ]
+    records = [{"id": i, "name": name, "image": {"bytes": img_bytes}} for i, (name, img_bytes) in enumerate(test_cases)]
+
+    # Compute embeddings
+    start = time.time()
+    clip_refiner.refine_batch(records)
+    print(f"    Embeddings computed in {time.time() - start:.2f}s")
+
+    embedding_field = clip_refiner.feature_field_name
+    print(f"    Embedding field: '{embedding_field}'")
+    print(f"    Embedding dim: {len(records[0][embedding_field])}")
+
+    # Step 2: Use aesthetic refiner with pre-computed embeddings
+    print("\n[2] Initializing ImageAestheticQualityRefiner with embedding_field...")
+    start = time.time()
+    aesthetic_refiner = ImageAestheticQualityRefiner(
+        embedding_field=embedding_field,  # Reuse embeddings!
+        inference_batch_size=8,
+        use_fp16=False,
+    )
+    print(f"    Aesthetic MLP loaded in {time.time() - start:.2f}s (no CLIP loading!)")
+
+    # Predict aesthetic scores
+    print("\n[3] Predicting aesthetic scores from embeddings...")
+    start = time.time()
+    aesthetic_refiner.refine_batch(records)
+    print(f"    Prediction took {time.time() - start:.4f}s (fast - no CLIP inference!)")
+
+    # Print results
+    print("\n[4] Results:")
+    print("-" * 50)
+    for record in records:
+        score = record.get("image_aesthetic_score", 0.0)
+        print(f"    {record['name']:20s} -> score: {score:.4f}")
+    print("-" * 50)
+
+
+def test_standalone_mode():
+    """Test mode 2: Compute embeddings internally (standalone)."""
+    print("\n" + "=" * 70)
+    print("Mode 2: Standalone (compute embeddings internally)")
+    print("=" * 70)
+
+    # Initialize refiner without embedding_field
+    print("\n[1] Initializing ImageAestheticQualityRefiner (standalone)...")
+    start = time.time()
+    refiner = ImageAestheticQualityRefiner(
+        embedding_field=None,  # Compute embeddings internally
+        inference_batch_size=8,
+        use_fp16=False,
+    )
+    print(f"    Initialization took {time.time() - start:.2f}s (includes CLIP loading)")
+
+    # Create test records
+    test_cases = [
+        ("Solid blue", create_test_image(512, 512, (50, 100, 200), "solid")),
+        ("Gradient", create_test_image(512, 512, (0, 0, 0), "gradient")),
+        ("Random noise", create_test_image(512, 512, (0, 0, 0), "noise")),
+    ]
+    records = [{"id": i, "name": name, "image": {"bytes": img_bytes}} for i, (name, img_bytes) in enumerate(test_cases)]
+
+    # Predict aesthetic scores
+    print("\n[2] Running inference (CLIP + MLP)...")
+    start = time.time()
+    refiner.refine_batch(records)
+    print(f"    Inference took {time.time() - start:.2f}s")
+
+    # Print results
+    print("\n[3] Results:")
+    print("-" * 50)
+    for record in records:
+        score = record.get("image_aesthetic_score", 0.0)
+        print(f"    {record['name']:20s} -> score: {score:.4f}")
+    print("-" * 50)
+
+
+def main():
+    print("\n" + "=" * 70)
+    print("ImageAestheticQualityRefiner Test Suite")
+    print("=" * 70)
+
+    # Test both modes
+    test_with_precomputed_embeddings()
+    test_standalone_mode()
+
+    print("\n" + "=" * 70)
+    print("All tests completed successfully!")
+    print("=" * 70)
+    print("\nRecommendation: Use Mode 1 (pre-computed embeddings) in pipelines")
+    print("to avoid redundant CLIP computation when you already have embeddings.")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -237,6 +237,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "datasets" },
     { name = "ffmpeg-python" },
+    { name = "huggingface-hub" },
     { name = "imagehash" },
     { name = "joblib" },
     { name = "numpy" },
@@ -246,6 +247,7 @@ dependencies = [
     { name = "pyiceberg" },
     { name = "pyyaml" },
     { name = "ray", extra = ["data", "default"] },
+    { name = "safetensors" },
     { name = "scikit-learn" },
 ]
 
@@ -265,6 +267,7 @@ ml = [
 requires-dist = [
     { name = "datasets", specifier = ">=4.5.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
+    { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "imagehash", specifier = ">=4.3.2" },
     { name = "joblib", specifier = ">=1.3.0" },
     { name = "langdetect", marker = "extra == 'enhanced'", specifier = ">=1.0.9" },
@@ -278,6 +281,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'enhanced'", specifier = ">=0.3.10" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ray", extras = ["data", "default"], specifier = ">=2.53.0" },
+    { name = "safetensors", specifier = ">=0.4.0" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "torch", marker = "extra == 'ml'", specifier = ">=2.0.0" },
     { name = "torchvision", marker = "extra == 'ml'", specifier = ">=0.15.0" },


### PR DESCRIPTION
## Summary

- Add `ImageAestheticQualityRefiner` for predicting aesthetic quality scores using the [improved-aesthetic-predictor](https://github.com/christophschuhmann/improved-aesthetic-predictor) model
- Supports two modes: reusing pre-computed CLIP embeddings (recommended) or standalone with internal CLIP computation
- Add `huggingface-hub` and `safetensors` dependencies for model downloading

## Details

The aesthetic predictor uses:
- **CLIP ViT-L/14** (768-dim embeddings) from OpenCLIP
- **MLP predictor** from [ttj/sac-logos-ava1-l14-linearMSE](https://huggingface.co/ttj/sac-logos-ava1-l14-linearMSE) trained on AVA dataset + LAION logos

Output field: `image_aesthetic_score` (typically 1-10 scale, higher = more visually appealing)

### Usage Examples

**Mode 1: Reuse pre-computed embeddings (recommended)**
```yaml
- name: clip_embedding_stage
  operators:
    - name: image_clip_embedding_refiner
      params:
        model_name: "ViT-L-14"  # Must be ViT-L-14

- name: aesthetic_quality_stage
  operators:
    - name: image_aesthetic_quality_refiner
      params:
        embedding_field: "image_clip_emb_vit_l_14"  # Reuse!
```

**Mode 2: Standalone**
```yaml
- name: aesthetic_quality_stage
  operators:
    - name: image_aesthetic_quality_refiner
      params:
        embedding_field: null  # Compute internally
```

## Test plan

- [x] Test with pre-computed embeddings mode
- [x] Test standalone mode
- [x] Verify consistent scores between both modes
- [x] Linter checks passed