### PR TITLE
feat(llm): add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ mdf run -c configs/z_image.yaml --max-samples 1000 --batch-size 500
 
 | Operator | Description | Mode |
 |----------|-------------|------|
-| [`LLMOnlineSynthesisRefiner`](mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md) | Call remote LLM APIs (OpenAI, Claude, Gemini, DeepSeek, etc.) with account pool + proxy pool | Online |
+| [`LLMOnlineSynthesisRefiner`](mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md) | Call remote LLM APIs (OpenAI, Claude, Gemini, MiniMax, DeepSeek, etc.) with account pool + proxy pool | Online |
 | [`LLMOfflineSynthesisRefiner`](mega_data_factory/operators/refiners/llm_synthesis/llm_offline_synthesis.md) | Run models locally on GPUs via vLLM engine for high-throughput batch inference | Offline |
 | [`LLMResponseParserRefiner`](mega_data_factory/operators/refiners/llm_synthesis/llm_response_parser.md) | Post-process LLM responses: JSON/regex/JMESPath extraction, schema validation, field mapping | Post-processing |
 
 ![LLM Synthesis Architecture](mega_data_factory/operators/refiners/llm_synthesis/architecture.png)
 
-**Online mode** supports any OpenAI-compatible endpoint (vLLM server, Ollama, Together, Groq) plus native Anthropic and Gemini APIs. Account pool rotates API keys with rate-limit awareness; proxy pool rotates HTTP/SOCKS proxies with failure tracking.
+**Online mode** supports any OpenAI-compatible endpoint (vLLM server, Ollama, Together, Groq) plus native Anthropic, Gemini, and [MiniMax](https://www.minimax.io) APIs. Account pool rotates API keys with rate-limit awareness; proxy pool rotates HTTP/SOCKS proxies with failure tracking.
 
 **Offline mode** uses vLLM's Python API for zero-HTTP-overhead GPU inference with continuous batching, tensor parallelism, and quantization (AWQ/GPTQ) support.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,62 @@
+"""
+conftest.py — Patch missing runtime dependencies for the test environment.
+
+This file is executed by pytest before any test collection, making the patches
+available to all test modules regardless of import order.
+"""
+
+import sys
+import types
+from datetime import timezone
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Backport datetime.UTC for Python 3.10 (the project targets Python 3.11+).
+# ---------------------------------------------------------------------------
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = timezone.utc
+
+# ---------------------------------------------------------------------------
+# Stub out optional heavy dependencies that are not installed in the CI
+# environment used for unit tests.  Tests that actually exercise these
+# modules are skipped separately with pytest.importorskip / pytest.mark.
+# ---------------------------------------------------------------------------
+
+
+def _make_package(name: str) -> types.ModuleType:
+    """Create a real (but empty) module and register it in sys.modules."""
+    mod = types.ModuleType(name)
+    mod.__package__ = name
+    mod.__path__ = []  # type: ignore[assignment]  # marks it as a package
+    sys.modules[name] = mod
+    return mod
+
+
+def _make_module(name: str, parent: types.ModuleType | None = None) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__package__ = name.rsplit(".", 1)[0] if "." in name else name
+    sys.modules[name] = mod
+    if parent is not None:
+        setattr(parent, name.rsplit(".", 1)[-1], mod)
+    return mod
+
+
+# resiliparse stubs
+_rs = _make_package("resiliparse")
+_rs_extract = _make_package("resiliparse.extract")
+_rs.extract = _rs_extract  # type: ignore[attr-defined]
+
+_rs_extract_html = _make_module("resiliparse.extract.html2text", _rs_extract)
+_rs_extract_html.extract_plain_text = MagicMock(return_value="")
+
+_rs_parse = _make_package("resiliparse.parse")
+_rs.parse = _rs_parse  # type: ignore[attr-defined]
+
+_rs_parse_enc = _make_module("resiliparse.parse.encoding", _rs_parse)
+_rs_parse_enc.bytes_to_str = MagicMock(return_value="")
+_rs_parse_enc.detect_encoding = MagicMock(return_value="utf-8")
+
+_rs_parse_lang = _make_module("resiliparse.parse.lang", _rs_parse)
+_rs_parse_lang.detect_fast = MagicMock(return_value="en")

--- a/mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md
+++ b/mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md
@@ -1,6 +1,6 @@
 # LLMOnlineSynthesisRefiner
 
-Calls remote LLM APIs (OpenAI, Claude, Gemini, DeepSeek, and any OpenAI-compatible endpoint) to synthesize responses from seed prompts. Features account pool rotation and proxy pool for anti-throttling.
+Calls remote LLM APIs (OpenAI, Claude, Gemini, MiniMax, DeepSeek, and any OpenAI-compatible endpoint) to synthesize responses from seed prompts. Features account pool rotation and proxy pool for anti-throttling.
 
 For local GPU inference without HTTP overhead, see [LLMOfflineSynthesisRefiner](llm_offline_synthesis.md).
 
@@ -14,7 +14,7 @@ pip install -e ".[llm-online]"   # installs httpx[socks]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `provider` | str | `"openai"` | LLM provider: `"openai"`, `"anthropic"`, `"gemini"` |
+| `provider` | str | `"openai"` | LLM provider: `"openai"`, `"anthropic"`, `"gemini"`, `"minimax"` |
 | `model` | str | `"gpt-4o"` | Model identifier |
 | `system_prompt` | str | `None` | System prompt prepended to every request |
 | `prompt_field` | str | `"prompt"` | Record field containing the text prompt |
@@ -57,6 +57,7 @@ pip install -e ".[llm-online]"   # installs httpx[socks]
 | OpenAI | `"openai"` | o-series `reasoning_content` | — |
 | Anthropic Claude | `"anthropic"` | Extended thinking | Base64 video |
 | Google Gemini | `"gemini"` | Gemini 2.5 thinking | Inline video |
+| MiniMax | `"minimax"` | think-tag strip | — |
 | DeepSeek | `"openai"` + `base_url` | R1 `reasoning_content` | — |
 | Together / Groq / vLLM server | `"openai"` + `base_url` | — | — |
 
@@ -114,7 +115,24 @@ operators:
           base_url: "https://api.deepseek.com/v1"
 ```
 
-### Prompt template with multiple record fields
+### MiniMax M2.7
+
+```yaml
+operators:
+  - name: llm_online_synthesis_refiner
+    params:
+      provider: minimax
+      model: MiniMax-M2.7
+      system_prompt: "You are a helpful assistant."
+      prompt_field: prompt
+      max_tokens: 4096
+      temperature: 0.7
+      accounts:
+        - api_key: "${MINIMAX_API_KEY}"
+      max_concurrent: 8
+```
+
+
 
 ```yaml
 operators:

--- a/mega_data_factory/operators/refiners/llm_synthesis/providers.py
+++ b/mega_data_factory/operators/refiners/llm_synthesis/providers.py
@@ -1,5 +1,5 @@
 """
-LLM Provider implementations for OpenAI, Anthropic (Claude), and Google Gemini.
+LLM Provider implementations for OpenAI, Anthropic (Claude), Google Gemini, and MiniMax.
 
 Each provider handles API-specific request formatting, multimodal content encoding,
 response parsing, and rate-limit detection. All providers use raw HTTP via httpx
@@ -430,8 +430,41 @@ class GeminiProvider(LLMProvider):
         return response.status_code == 429
 
 
+class MiniMaxProvider(OpenAIProvider):
+    """Provider for MiniMax API (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed).
+
+    Uses MiniMax's OpenAI-compatible endpoint at api.minimax.io/v1.
+    Temperature is clamped to (0.0, 1.0] per MiniMax API constraints.
+    Thinking tags emitted by reasoning models are stripped from the response.
+    """
+
+    DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+    # MiniMax requires temperature in (0.0, 1.0] — clamp silently to avoid errors.
+    _TEMP_MIN = 1e-6
+    _TEMP_MAX = 1.0
+
+    def build_request(self, *, temperature, **kwargs):
+        clamped = max(self._TEMP_MIN, min(self._TEMP_MAX, temperature))
+        return super().build_request(temperature=clamped, **kwargs)
+
+    def parse_response(self, response):
+        import re
+
+        result = super().parse_response(response)
+        # Strip <think>...</think> blocks emitted by reasoning-capable models.
+        if result.content and "<think>" in result.content:
+            think_match = re.search(r"<think>(.*?)</think>", result.content, re.DOTALL)
+            if think_match:
+                result.thinking = (result.thinking or "") + think_match.group(1)
+                result.content = re.sub(
+                    r"<think>.*?</think>", "", result.content, flags=re.DOTALL
+                ).strip()
+        return result
+
+
 PROVIDERS: dict[str, type[LLMProvider]] = {
     "openai": OpenAIProvider,
     "anthropic": AnthropicProvider,
     "gemini": GeminiProvider,
+    "minimax": MiniMaxProvider,
 }

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,396 @@
+"""
+Unit and integration tests for MiniMaxProvider.
+
+Unit tests use mock HTTP responses; integration tests require MINIMAX_API_KEY.
+Run integration tests with: pytest tests/test_minimax_provider.py -m integration -v
+"""
+
+import os
+import sys
+from datetime import timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Backport datetime.UTC for Python 3.10 (the project targets 3.11+).
+# This must happen before any mega_data_factory import.
+# ---------------------------------------------------------------------------
+import datetime as _dt
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = timezone.utc
+
+from mega_data_factory.operators.refiners.llm_synthesis.providers import (
+    PROVIDERS,
+    MiniMaxProvider,
+    LLMResponse,
+)
+from mega_data_factory.operators.refiners.llm_synthesis.pool import Account
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_account(api_key="test-key", base_url=None):
+    return Account(api_key=api_key, base_url=base_url, org_id=None)
+
+
+def _make_response(body: dict, status_code: int = 200):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = body
+    mock.headers = {}
+    return mock
+
+
+def _openai_body(content: str, model: str = "MiniMax-M2.7", usage: dict | None = None):
+    return {
+        "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+        "model": model,
+        "usage": usage or {"prompt_tokens": 10, "completion_tokens": 20},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: registration
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxRegistration:
+    def test_registered_in_providers(self):
+        assert "minimax" in PROVIDERS
+
+    def test_is_minimax_provider(self):
+        assert PROVIDERS["minimax"] is MiniMaxProvider
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: default base URL
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxDefaultBaseURL:
+    def test_default_url(self):
+        p = MiniMaxProvider()
+        assert p.DEFAULT_BASE_URL == "https://api.minimax.io/v1"
+
+    def test_builds_correct_url(self):
+        p = MiniMaxProvider()
+        account = _make_account()
+        url, _, _ = p.build_request(
+            prompt="hello",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7",
+            max_tokens=100,
+            temperature=0.7,
+            extra_params={},
+            account=account,
+        )
+        assert url == "https://api.minimax.io/v1/chat/completions"
+
+    def test_respects_custom_base_url(self):
+        p = MiniMaxProvider()
+        account = _make_account(base_url="https://custom.minimax.io/v1")
+        url, _, _ = p.build_request(
+            prompt="hello",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7",
+            max_tokens=100,
+            temperature=0.7,
+            extra_params={},
+            account=account,
+        )
+        assert url == "https://custom.minimax.io/v1/chat/completions"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: temperature clamping
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxTemperatureClamping:
+    def _get_body_temperature(self, temperature: float) -> float:
+        p = MiniMaxProvider()
+        account = _make_account()
+        _, _, body = p.build_request(
+            prompt="test",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7",
+            max_tokens=100,
+            temperature=temperature,
+            extra_params={},
+            account=account,
+        )
+        return body["temperature"]
+
+    def test_zero_clamped_to_minimum(self):
+        t = self._get_body_temperature(0.0)
+        assert t > 0.0
+
+    def test_above_one_clamped(self):
+        t = self._get_body_temperature(2.0)
+        assert t <= 1.0
+
+    def test_valid_temperature_unchanged(self):
+        t = self._get_body_temperature(0.7)
+        assert abs(t - 0.7) < 1e-9
+
+    def test_one_is_valid(self):
+        t = self._get_body_temperature(1.0)
+        assert t == 1.0
+
+    def test_negative_clamped(self):
+        t = self._get_body_temperature(-0.5)
+        assert t > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: request building
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxRequestBuilding:
+    def test_bearer_auth_header(self):
+        p = MiniMaxProvider()
+        account = _make_account(api_key="mm-secret")
+        _, headers, _ = p.build_request(
+            prompt="hi",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7",
+            max_tokens=100,
+            temperature=0.7,
+            extra_params={},
+            account=account,
+        )
+        assert headers["Authorization"] == "Bearer mm-secret"
+
+    def test_model_in_body(self):
+        p = MiniMaxProvider()
+        account = _make_account()
+        _, _, body = p.build_request(
+            prompt="hi",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7-highspeed",
+            max_tokens=100,
+            temperature=0.7,
+            extra_params={},
+            account=account,
+        )
+        assert body["model"] == "MiniMax-M2.7-highspeed"
+
+    def test_system_prompt_included(self):
+        p = MiniMaxProvider()
+        account = _make_account()
+        _, _, body = p.build_request(
+            prompt="hi",
+            system_prompt="You are helpful.",
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.7",
+            max_tokens=100,
+            temperature=0.7,
+            extra_params={},
+            account=account,
+        )
+        assert body["messages"][0] == {"role": "system", "content": "You are helpful."}
+
+    def test_m25_highspeed_model(self):
+        p = MiniMaxProvider()
+        account = _make_account()
+        _, _, body = p.build_request(
+            prompt="hi",
+            system_prompt=None,
+            image_data=None,
+            image_media_type="",
+            video_data=None,
+            video_media_type="",
+            model="MiniMax-M2.5-highspeed",
+            max_tokens=100,
+            temperature=0.5,
+            extra_params={},
+            account=account,
+        )
+        assert body["model"] == "MiniMax-M2.5-highspeed"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: response parsing
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxResponseParsing:
+    def test_normal_response(self):
+        p = MiniMaxProvider()
+        response = _make_response(_openai_body("Hello world"))
+        result = p.parse_response(response)
+        assert result.content == "Hello world"
+        assert result.error == ""
+
+    def test_think_tag_stripped(self):
+        p = MiniMaxProvider()
+        body = _openai_body("<think>internal reasoning</think>Final answer.")
+        response = _make_response(body)
+        result = p.parse_response(response)
+        assert "<think>" not in result.content
+        assert result.content == "Final answer."
+        assert "internal reasoning" in result.thinking
+
+    def test_think_tag_multiline(self):
+        p = MiniMaxProvider()
+        body = _openai_body("<think>\nline1\nline2\n</think>Result.")
+        response = _make_response(body)
+        result = p.parse_response(response)
+        assert result.content == "Result."
+        assert "line1" in result.thinking
+
+    def test_no_think_tag(self):
+        p = MiniMaxProvider()
+        body = _openai_body("Plain answer.")
+        response = _make_response(body)
+        result = p.parse_response(response)
+        assert result.content == "Plain answer."
+        assert result.thinking == ""
+
+    def test_error_response(self):
+        p = MiniMaxProvider()
+        body = {"error": {"message": "Invalid API key", "code": 401}}
+        response = _make_response(body)
+        result = p.parse_response(response)
+        assert "Invalid API key" in result.error
+
+    def test_rate_limited(self):
+        p = MiniMaxProvider()
+        response = _make_response({}, status_code=429)
+        assert p.is_rate_limited(response) is True
+
+    def test_not_rate_limited(self):
+        p = MiniMaxProvider()
+        response = _make_response(_openai_body("ok"), status_code=200)
+        assert p.is_rate_limited(response) is False
+
+    def test_usage_fields(self):
+        p = MiniMaxProvider()
+        body = _openai_body("hi", usage={"prompt_tokens": 5, "completion_tokens": 15})
+        response = _make_response(body)
+        result = p.parse_response(response)
+        assert result.input_tokens == 5
+        assert result.output_tokens == 15
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: online refiner integration
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxOnlineRefiner:
+    """Smoke tests for MiniMaxProvider inside LLMOnlineSynthesisRefiner."""
+
+    @pytest.fixture(autouse=True)
+    def _load_online(self):
+        from mega_data_factory.operators.refiners.llm_synthesis.online import LLMOnlineSynthesisRefiner
+        self.LLMOnlineSynthesisRefiner = LLMOnlineSynthesisRefiner
+
+    def test_refiner_accepts_minimax_provider(self):
+        refiner = self.LLMOnlineSynthesisRefiner(
+            provider="minimax",
+            model="MiniMax-M2.7",
+            accounts=[{"api_key": "test-key"}],
+        )
+        assert isinstance(refiner.provider, MiniMaxProvider)
+
+    def test_refiner_rejects_unknown_provider(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            self.LLMOnlineSynthesisRefiner(
+                provider="nonexistent",
+                model="some-model",
+                accounts=[{"api_key": "test-key"}],
+            )
+
+    def test_refiner_calls_minimax_api(self):
+        refiner = self.LLMOnlineSynthesisRefiner(
+            provider="minimax",
+            model="MiniMax-M2.7",
+            accounts=[{"api_key": "test-key"}],
+            max_concurrent=1,
+        )
+
+        with patch.object(refiner, "_call_llm", return_value=LLMResponse(content="Synthesized content", model="MiniMax-M2.7")):
+            records = [{"prompt": "Explain quantum computing."}]
+            refiner.refine_batch(records)
+            assert records[0]["llm_response"] == "Synthesized content"
+            assert records[0]["llm_error"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require MINIMAX_API_KEY)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestMiniMaxIntegration:
+    """Live API tests. Run with: pytest -m integration"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        key = os.environ.get("MINIMAX_API_KEY")
+        if not key:
+            pytest.skip("MINIMAX_API_KEY not set")
+        self.api_key = key
+        from mega_data_factory.operators.refiners.llm_synthesis.online import LLMOnlineSynthesisRefiner
+        self.LLMOnlineSynthesisRefiner = LLMOnlineSynthesisRefiner
+
+    def test_m27_basic_call(self):
+        refiner = self.LLMOnlineSynthesisRefiner(
+            provider="minimax",
+            model="MiniMax-M2.7",
+            accounts=[{"api_key": self.api_key}],
+            max_tokens=64,
+        )
+        records = [{"prompt": "Say 'hello' in one word."}]
+        refiner.refine_batch(records)
+        assert records[0]["llm_error"] == ""
+        assert len(records[0]["llm_response"]) > 0
+
+    def test_m27_highspeed_basic_call(self):
+        refiner = self.LLMOnlineSynthesisRefiner(
+            provider="minimax",
+            model="MiniMax-M2.7-highspeed",
+            accounts=[{"api_key": self.api_key}],
+            max_tokens=64,
+        )
+        records = [{"prompt": "What is 2 + 2?"}]
+        refiner.refine_batch(records)
+        assert records[0]["llm_error"] == ""
+        # Answer may land in response or thinking depending on model mode.
+        combined = records[0]["llm_response"] + records[0]["llm_thinking"]
+        assert "4" in combined
+
+    def test_temperature_zero_clamped(self):
+        # temperature=0.0 would be rejected by MiniMax; provider should clamp it.
+        refiner = self.LLMOnlineSynthesisRefiner(
+            provider="minimax",
+            model="MiniMax-M2.7",
+            accounts=[{"api_key": self.api_key}],
+            max_tokens=32,
+            temperature=0.0,
+        )
+        records = [{"prompt": "Say 'ok'."}]
+        refiner.refine_batch(records)
+        # If clamping works, no error should be returned.
+        assert records[0]["llm_error"] == ""


### PR DESCRIPTION
## Summary

- Add `MiniMaxProvider` to the `llm_synthesis` provider registry alongside OpenAI, Anthropic, and Gemini
- MiniMax uses its OpenAI-compatible API (`api.minimax.io/v1`) with two specializations: temperature clamping to `(0.0, 1.0]` and think-tag stripping from reasoning model responses
- Supports `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` (204K context window)

## Usage

```python
from mega_data_factory.operators.refiners.llm_synthesis import LLMOnlineSynthesisRefiner

refiner = LLMOnlineSynthesisRefiner(
    provider="minimax",
    model="MiniMax-M2.7",
    accounts=[{"api_key": "YOUR_MINIMAX_API_KEY"}],
)
refiner.refine_batch(records)
```

Or in YAML config:

```yaml
operators:
  - name: llm_online_synthesis_refiner
    params:
      provider: minimax
      model: MiniMax-M2.7
      max_tokens: 4096
      temperature: 0.7
      accounts:
        - api_key: "${MINIMAX_API_KEY}"
```

## Changes

- `mega_data_factory/operators/refiners/llm_synthesis/providers.py`: add `MiniMaxProvider` class (inherits `OpenAIProvider`), register as `"minimax"` in `PROVIDERS` dict
- `mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md`: add MiniMax to provider table and YAML config example
- `README.md`: mention MiniMax in LLM Synthesis section
- `tests/test_minimax_provider.py`: 25 unit + 3 integration tests
- `conftest.py`: stubs for optional deps (`resiliparse`, `datetime.UTC` backport for Python 3.10)

## Test plan

- [x] 25 unit tests pass (`pytest tests/test_minimax_provider.py -m 'not integration'`)
- [x] 3 integration tests pass against live MiniMax API (`MINIMAX_API_KEY=... pytest -m integration`)