### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md
+++ b/mega_data_factory/operators/refiners/llm_synthesis/llm_online_synthesis.md
@@ -115,14 +115,14 @@ operators:
           base_url: "https://api.deepseek.com/v1"
 ```
 
-### MiniMax M2.7
+### MiniMax M3
 
 ```yaml
 operators:
   - name: llm_online_synthesis_refiner
     params:
       provider: minimax
-      model: MiniMax-M2.7
+      model: MiniMax-M3
       system_prompt: "You are a helpful assistant."
       prompt_field: prompt
       max_tokens: 4096

--- a/mega_data_factory/operators/refiners/llm_synthesis/providers.py
+++ b/mega_data_factory/operators/refiners/llm_synthesis/providers.py
@@ -431,7 +431,10 @@ class GeminiProvider(LLMProvider):
 
 
 class MiniMaxProvider(OpenAIProvider):
-    """Provider for MiniMax API (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed).
+    """Provider for MiniMax API (M3, M2.7, M2.7-highspeed).
+
+    M3 is the current flagship (512K context, 128K max output, image input
+    support). M2.7 family is retained for backward compatibility.
 
     Uses MiniMax's OpenAI-compatible endpoint at api.minimax.io/v1.
     Temperature is clamped to (0.0, 1.0] per MiniMax API constraints.

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -44,7 +44,7 @@ def _make_response(body: dict, status_code: int = 200):
     return mock
 
 
-def _openai_body(content: str, model: str = "MiniMax-M2.7", usage: dict | None = None):
+def _openai_body(content: str, model: str = "MiniMax-M3", usage: dict | None = None):
     return {
         "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
         "model": model,
@@ -213,7 +213,7 @@ class TestMiniMaxRequestBuilding:
         )
         assert body["messages"][0] == {"role": "system", "content": "You are helpful."}
 
-    def test_m25_highspeed_model(self):
+    def test_m3_model(self):
         p = MiniMaxProvider()
         account = _make_account()
         _, _, body = p.build_request(
@@ -223,13 +223,13 @@ class TestMiniMaxRequestBuilding:
             image_media_type="",
             video_data=None,
             video_media_type="",
-            model="MiniMax-M2.5-highspeed",
+            model="MiniMax-M3",
             max_tokens=100,
             temperature=0.5,
             extra_params={},
             account=account,
         )
-        assert body["model"] == "MiniMax-M2.5-highspeed"
+        assert body["model"] == "MiniMax-M3"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the default.

## Changes
- Update `MiniMaxProvider` docstring to list `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`
- Switch the `llm_online_synthesis.md` example over to `MiniMax-M3`
- Update unit tests to default to `MiniMax-M3` and replace the deprecated `MiniMax-M2.5-highspeed` test with a `MiniMax-M3` test
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as backward-compatible options
- Drop references to the deprecated `MiniMax-M2.5` / `M2.5-highspeed` family

## Why
MiniMax-M3 is the new flagship with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Surfacing it in the docs and tests makes it discoverable as the recommended default while preserving M2.7 as an explicit fallback. This is a documentation- and test-only change; existing user configs that pin a specific model name keep working unchanged.

## Testing
- `MiniMaxProvider` unit tests updated (registration, default base URL, temperature clamping, request building, response parsing) and passing
- Verified M2.7 / M2.7-highspeed model strings still flow through unchanged
- API base URL (`https://api.minimax.io/v1`) and temperature clamp `(0, 1]` behavior preserved